### PR TITLE
Remove egulias/email-validator and use filter_var instead

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,8 +36,7 @@
     },
     "require": {
         "php": ">=7.2.0",
-        "silverstripe/framework": "^4.0",
-        "egulias/email-validator": "^3.2"
+        "silverstripe/framework": "^4.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.7",

--- a/src/ValidationRules.php
+++ b/src/ValidationRules.php
@@ -2,8 +2,6 @@
 
 namespace Cube\SilverStripe\Validation;
 
-use Egulias\EmailValidator\EmailValidator;
-use Egulias\EmailValidator\Validation\RFCValidation;
 use Exception;
 use SilverStripe\Core\ClassInfo;
 use Cube\SilverStripe\Validation\Interfaces\Rule;
@@ -183,8 +181,6 @@ class ValidationRules
      */
     protected function validateEmail($value)
     {
-        $validator = new EmailValidator();
-
-        return $validator->isValid($value, new RFCValidation());
+        return filter_var($value, FILTER_VALIDATE_EMAIL);
     }
 }


### PR DESCRIPTION
When using `egulias/email-validator` some specific combinations are marked valid when it's not.

For example: test@test

By using the build in PHP `filter_var` the validation rule works as expected.